### PR TITLE
Use an Alpine base image, add `.dockerignore` file, and other tweaks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+_build
+deps
+assets/node_modules
+test

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,13 +22,6 @@ RUN mix do deps.get, release
 
 RUN chmod +x /app/entrypoint.sh
 
-# USER default
-# 
-# # Mutable Runtime Environment
-# RUN mkdir /tmp/app
-# ENV RELEASE_MUTABLE_DIR /tmp/app
-# ENV START_ERL_DATA /tmp/app/start_erl.data
-
 ENTRYPOINT ["/app/entrypoint.sh"]
 
-CMD ["mix", "phx.server"]
+CMD ["/app/_build/dev/rel/todo/bin/todo", "foreground"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,34 @@
-# Use an official Elixir runtime as a parent image
-FROM elixir:latest
+FROM bitwalker/alpine-elixir-phoenix:1.8.0
 
-RUN apt-get update && \
-  apt-get install -y postgresql-client
+RUN apk update \
+  && apk add --no-cache postgresql-client \
+  && rm -rf /var/cache/apk/*
+
+ARG MIX_ENV=dev
+ENV MIX_ENV ${MIX_ENV}
+
+# Set exposed ports
+EXPOSE 4000
+ENV PORT=4000
 
 # Create app directory and copy the Elixir projects into it
 RUN mkdir /app
-COPY . /app
 WORKDIR /app
 
-# Install hex package manager
-RUN mix local.hex --force && \
-  mix local.rebar --force
+ADD . ./
 
-# Compile the project
-RUN mix do deps.get, \
-  deps.compile, \
-  compile
+# Get deps & compile project
+RUN mix do deps.get, release
 
 RUN chmod +x /app/entrypoint.sh
 
-CMD ["/app/entrypoint.sh"]
+# USER default
+# 
+# # Mutable Runtime Environment
+# RUN mkdir /tmp/app
+# ENV RELEASE_MUTABLE_DIR /tmp/app
+# ENV START_ERL_DATA /tmp/app/start_erl.data
+
+ENTRYPOINT ["/app/entrypoint.sh"]
+
+CMD ["mix", "phx.server"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,4 +17,4 @@ if [[ -z `psql -Atqc "\\list $PGDATABASE"` ]]; then
   echo "Database $PGDATABASE created."
 fi
 
-exec mix phx.server
+exec $@

--- a/mix.exs
+++ b/mix.exs
@@ -33,12 +33,12 @@ defmodule Todo.Mixfile do
   # Type `mix help deps` for examples and options.
   defp deps do
     [
-      {:phoenix, "~> 1.4.0"},
+      {:phoenix, "~> 1.4"},
       {:phoenix_pubsub, "~> 1.0"},
-      {:phoenix_ecto, "~> 3.2"},
+      {:phoenix_ecto, "~> 3.6"},
       {:postgrex, ">= 0.0.0"},
       {:phoenix_html, "~> 2.10"},
-      {:phoenix_live_reload, "~> 1.0", only: :dev},
+      {:phoenix_live_reload, "~> 1.2", only: :dev},
       {:gettext, "~> 0.11"},
       {:plug_cowboy, "~> 2.0"},
       {:timex, "~> 3.1"},


### PR DESCRIPTION
This creates an image of about 355 MB, versus over 1GB with `elixir:latest` as a base image. This base image also means we don't need to install `hex` or `rebar`. I also updated some of the dependencies.